### PR TITLE
dead loop when the first block is bigger than the size retention.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20180518154759-7600349dcfe1
 	github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 // indirect
-	github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022
+	github.com/prometheus/tsdb v0.1.1-0.20181125144603-3677a7618afa
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
 	github.com/rlmcpherson/s3gof3r v0.5.0 // indirect
 	github.com/rubyist/circuitbreaker v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 h1:IrO4Eb9oGw+Gx
 github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022 h1:EIEFPDBN3/+3GuBw/V3RcFV7/efdVNhqxuaMne2RrGU=
 github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022/go.mod h1:lFf/o1J2a31WmWQbxYXfY1azJK5Xp5D8hwKMnVMBTGU=
+github.com/prometheus/tsdb v0.1.1-0.20181125144603-3677a7618afa h1:/SL6I4Hurskc1HAwoMvbUTyD9ub/wRTm00tBb07dMbQ=
+github.com/prometheus/tsdb v0.1.1-0.20181125144603-3677a7618afa/go.mod h1:lFf/o1J2a31WmWQbxYXfY1azJK5Xp5D8hwKMnVMBTGU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rlmcpherson/s3gof3r v0.5.0 h1:1izOJpTiohSibfOHuNyEA/yQnAirh05enzEdmhez43k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/prometheus/common/route
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9
 github.com/prometheus/procfs
-# github.com/prometheus/tsdb v0.1.1-0.20181120193419-f9476466d022
+# github.com/prometheus/tsdb v0.1.1-0.20181125144603-3677a7618afa
 github.com/prometheus/tsdb
 github.com/prometheus/tsdb/labels
 github.com/prometheus/tsdb/chunkenc


### PR DESCRIPTION
found and fixed one bug when the size retention is so low that it gets deleted right after it is created so the head is not truncated and it goes into a dead loop.

https://github.com/prometheus/tsdb/commit/3677a7618afab10e0c74f34a405be59bdae2d624